### PR TITLE
Add APIs exposed in ShadowRealms

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -45,6 +45,7 @@ Interfaces:
 * {{CountQueuingStrategy}} [[!STREAMS]]
 * {{Crypto}} [[!WEBCRYPTO]]
 * {{CryptoKey}} [[!WEBCRYPTO]]
+* {{CustomEvent}} [[!HTML]]
 * {{DecompressionStream}} [[!COMPRESSION]]
 * {{DOMException}} [[!WEBIDL]]
 * {{ErrorEvent}} [[!HTML]]
@@ -102,6 +103,15 @@ Global methods / properties:
 * `globalThis.`{{performance}}.{{Performance/now()}} [[!HR-TIME]]
 * `globalThis.`{{performance}}.{{timeOrigin}} [[!HR-TIME]]
 * `globalThis.`{{queueMicrotask()}} [[!HTML]]
+* `globalThis.`{{reportError()}} [[!HTML]]
+* `globalThis.`self (on {{Window/self|Window}} and {{WorkerGlobalScope/self|WorkerGlobalScope}}) [[!HTML]]
+
+    Note: This returns the value of `globalThis`.
+
+    Issue: When the <a href="https://github.com/whatwg/html/pull/9893">ShadowRealm integration PR</a>
+    is merged into the HTML spec,
+    `self` will also need to be exposed on `ShadowRealmGlobalScope`.
+
 * `globalThis.`{{setTimeout()}} / globalThis.{{clearTimeout()}} [[!HTML]]
 * `globalThis.`{{setInterval()}} / globalThis.{{clearInterval()}} [[!HTML]]
 * `globalThis.`{{structuredClone()}} [[!HTML]]


### PR DESCRIPTION
As discussed in today's meeting, this PR adds the `CustomEvent`, `globalThis.reportError()` and `globalThis.self` APIs to the Minimum Common API. This is done because they will be exposed in ShadowRealms in browsers, and it is useful for code running in ShadowRealms to also be able to run in server-side runtimes.