### PR TITLE
Refactor `onerror` and similar properties for windows and workers

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -107,18 +107,13 @@ All of the following methods and properties MUST be exposed on the global object
 * `globalThis.`{{crypto}} [[!WEBCRYPTO]]
 * `globalThis.`{{fetch()}} [[!FETCH]]
 * `globalThis.`{{navigator}}.{{userAgent}} [[!HTML]]
-* `globalThis.onerror` (on {{GlobalEventHandlers/onerror|Window}} and {{WorkerGlobalScope/onerror|WorkerGlobalScope}}) [[!HTML]]
-* `globalThis.onunhandledrejection` (on {{WindowEventHandlers/onunhandledrejection|Window}} and {{WorkerGlobalScope/onunhandledrejection|WorkerGlobalScope}}) [[!HTML]]
-* `globalThis.onrejectionhandled` (on {{WindowEventHandlers/onrejectionhandled|Window}} and {{WorkerGlobalScope/onrejectionhandled|WorkerGlobalScope}}) [[!HTML]]
+* `globalThis.`{{GlobalEventHandlers/onerror}} [[!HTML]]
+* `globalThis.`{{WindowEventHandlers/onunhandledrejection}} [[!HTML]]
+* `globalThis.`{{WindowEventHandlers/onrejectionhandled}} [[!HTML]]
 * `globalThis.`{{performance}} [[!HR-TIME]]
 * `globalThis.`{{queueMicrotask()}} [[!HTML]]
 * `globalThis.`{{reportError()}} [[!HTML]]
-* `globalThis.`self (on {{Window/self|Window}} and {{WorkerGlobalScope/self|WorkerGlobalScope}}) [[!HTML]]
-
-    Issue: When the <a href="https://github.com/whatwg/html/pull/9893">ShadowRealm integration PR</a>
-    is merged into the HTML spec,
-    `self` will also need to be exposed on `ShadowRealmGlobalScope`.
-
+* `globalThis.`{{Window/self}} [[!HTML]]
 * `globalThis.`{{setTimeout()}} [[!HTML]]
 * `globalThis.`{{setInterval()}} [[!HTML]]
 * `globalThis.`{{structuredClone()}} [[!HTML]]
@@ -128,6 +123,11 @@ All of the following methods and properties MUST be exposed on the global object
 * `globalThis.`{{WebAssembly}}.{{WebAssembly/instantiateStreaming()}} [[!WASM-WEB-API-2]]
 * `globalThis.`{{WebAssembly}}.{{WebAssembly/JSTag}} [[!WASM-JS-API-2]]
 * `globalThis.`{{WebAssembly}}.{{WebAssembly/validate()}} [[!WASM-JS-API-2]]
+
+Web-interoperable runtimes that support workers MUST also expose {{WorkerGlobalScope/onerror}},
+{{WorkerGlobalScope/onunhandledrejection}}, {{WorkerGlobalScope/onrejectionhandled}} and
+{{WorkerGlobalScope/self}} on the worker's `globalThis`,
+unless otherwise specified in this specification. [[!HTML]]
 
 The Global Scope {#global-scope}
 ================================


### PR DESCRIPTION
`onerror`, `onunhandledrejection`, `onrejectionhandled` and `self` are all properties in the global scope that live in both `Window` and `WorkerGlobalScope`. However, unlike other properties that apply to both windows and workers, these properties are defined separately for windows and for workers.

The current spec text deals with them by listing the property name and linking in parenthesis to both definitions in the HTML spec. However, in this edition of the Minimum Common API specification, we don't talk a lot about workers, and we don't require runtimes to implement them.

This patch clarifies this by linking to the `Window` definitions in the main list of properties, and adding a paragraph after that that links to the `WorkerGlobalScope` defintions and specifies that runtimes with workers should also support them.

Additionally, we remove an issue about exposing `self` on the `ShadowRealmGlobalScope` in the future when whatwg/html#9893 lands, since the ShadowRealm proposal seems to have lost a lot of steam lately. We can always add a similar paragraph to the workers one if it ever picks up pace again.